### PR TITLE
Fix: [VIN-5] Fetch tracklist locally via API

### DIFF
--- a/lib/tracklist.ts
+++ b/lib/tracklist.ts
@@ -1,5 +1,5 @@
 
 export async function getTracks(masterId: string) {
-    const results = await fetch(`https://api.discogs.com/masters/${masterId}`)
+    const results = await fetch(`/api/discogs/master/${masterId}`)
     return results.json()
 }


### PR DESCRIPTION
Resolves [VIN-5](https://linear.app/berapoint/issue/VIN-5/mes-1-fix-fetch-de-tracklist-directo-a-discogs-desde-el-cliente) by calling the internal \/api/discogs/master/[id]\ endpoint instead of directly hitting Discogs, preventing credential leakage.