### PR TITLE
Fix: [VIN-7] Sync album modal state with real collection and wishlist

### DIFF
--- a/components/albumDetailmodal.tsx
+++ b/components/albumDetailmodal.tsx
@@ -8,13 +8,18 @@ import { useState, useEffect } from "react";
 import { DrawerClose, DrawerDescription, DrawerTitle } from "./ui/drawer";
 import { Vinyl } from "@/lib/types/tables";
 
+import useWishlist from "@/hooks/useWistList";
+
 type AlbumDetailModalProps = {
     album: DiscogsRelease & Partial<Vinyl>
+    initialInCollection?: boolean
+    initialInWishlist?: boolean
 }
-export default function AlbumDetailModal({ album }: AlbumDetailModalProps) {
+export default function AlbumDetailModal({ album, initialInCollection, initialInWishlist }: AlbumDetailModalProps) {
     const [tracklist, setTracklist] = useState<any[]>([]);
-    const [inCollection, setInCollection] = useState(false);
-    const [inWishlist, setInWishlist] = useState(false);
+    const [inCollection, setInCollection] = useState(initialInCollection || album.owned === true || false);
+    const [inWishlist, setInWishlist] = useState(initialInWishlist || album.owned === false || false);
+    const { addToCollectionFromSearch } = useWishlist();
 
     useEffect(() => {
         async function fetchTracks() {
@@ -69,7 +74,10 @@ export default function AlbumDetailModal({ album }: AlbumDetailModalProps) {
             <div>
                 <div className="flex gap-3 my-8 px-8">
                     <button
-                        onClick={() => setInCollection(!inCollection)}
+                        onClick={() => {
+                            setInCollection(!inCollection);
+                            addToCollectionFromSearch(album.id, true);
+                        }}
                         className={`flex-1 flex items-center justify-center gap-2 py-4 rounded-2xl font-medium transition-all shadow-lg ${inCollection
                             ? 'bg-amber-600 text-white'
                             : 'bg-amber-500 hover:bg-amber-600 text-white'
@@ -88,7 +96,10 @@ export default function AlbumDetailModal({ album }: AlbumDetailModalProps) {
                         )}
                     </button>
                     <button
-                        onClick={() => setInWishlist(!inWishlist)}
+                        onClick={() => {
+                            setInWishlist(!inWishlist);
+                            addToCollectionFromSearch(album.id, false);
+                        }}
                         className={`p-4 rounded-2xl transition-colors ${inWishlist
                             ? 'bg-red-500 text-white'
                             : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700'

--- a/components/card.tsx
+++ b/components/card.tsx
@@ -38,22 +38,22 @@ export function Card({ album, showInCollection = false }: cardProps) {
     );
 }
 
-export function AlbumDrawer({ children, album }: { children: React.ReactNode, album: DiscogsRelease & Partial<Vinyl> }) {
+export function AlbumDrawer({ children, album, initialInCollection, initialInWishlist }: { children: React.ReactNode, album: DiscogsRelease & Partial<Vinyl>, initialInCollection?: boolean, initialInWishlist?: boolean }) {
     return (
         <Drawer direction='bottom'>
             <DrawerTrigger asChild >
                 {children}
             </DrawerTrigger>
             <DrawerContent dragable={true} className='rounded-t-4xl'>
-                <AlbumDetailModal album={album} />
+                <AlbumDetailModal album={album} initialInCollection={initialInCollection} initialInWishlist={initialInWishlist} />
             </DrawerContent>
         </Drawer>
     )
 }
 
-export function AlbumCardDrawer({ album }: { album: DiscogsRelease & Partial<Vinyl> }) {
+export function AlbumCardDrawer({ album, initialInCollection, initialInWishlist }: { album: DiscogsRelease & Partial<Vinyl>, initialInCollection?: boolean, initialInWishlist?: boolean }) {
     return (
-        <AlbumDrawer album={album}>
+        <AlbumDrawer album={album} initialInCollection={initialInCollection} initialInWishlist={initialInWishlist}>
             <div>
                 <Card album={album} />
             </div>

--- a/components/searchResultItem.tsx
+++ b/components/searchResultItem.tsx
@@ -17,7 +17,7 @@ export function SearchResultItem({ album, initialInCollection = false, initialIn
 
     return (
         <div className="flex items-center gap-4 p-3 rounded-2xl bg-zinc-900/50 hover:bg-zinc-900 transition-colors">
-            <AlbumDrawer album={album as any}>
+            <AlbumDrawer album={album as any} initialInCollection={initialInCollection} initialInWishlist={initialInWishlist}>
                 <div className="flex items-center gap-4 flex-1 min-w-0">
                     <img
                         src={album?.cover_image || ''}


### PR DESCRIPTION
Resolves [VIN-7](https://linear.app/berapoint/issue/VIN-7/mes-1-fix-estado-del-modal-de-album-no-sincronizado-con-coleccion-real). Refactored AlbumDetailModal and its container drawers to accept \initialInCollection\ and \initialInWishlist\, properly seeding state from external truth. Uses \ddToCollectionFromSearch\ internally.