### PR TITLE
Feat: Add artist releases to drawer and fix search performance loop

### DIFF
--- a/app/api/discogs/artist/[artistId]/route.ts
+++ b/app/api/discogs/artist/[artistId]/route.ts
@@ -1,0 +1,17 @@
+import { getFetchDiscogs } from '@/utils/fetchDiscogs'
+import { NextResponse } from 'next/server'
+
+export async function GET(req: Request, { params }: { params: Promise<{ artistId: string }> }) {
+    const { artistId } = await params;
+    const { searchParams } = new URL(req.url)
+    const page = searchParams.get('page') ?? '1'
+    const per_page = searchParams.get('per_page') ?? '50'
+
+    const queryParams = new URLSearchParams({
+        page,
+        per_page
+    })
+
+    const data = await getFetchDiscogs(`https://api.discogs.com/artists/${artistId}/releases?${queryParams.toString()}`)
+    return NextResponse.json(data)
+}

--- a/app/api/discogs/search/route.ts
+++ b/app/api/discogs/search/route.ts
@@ -31,8 +31,7 @@ export async function GET(req: Request) {
     } else if (track) {
         params.set('track', track)
     }
-    // TODO: filtros avanzados agregar nombre del artista a la buquesa del album
-    // if (artist) params.set('artist', artist)
+
 
     const data = await getFetchDiscogs(`https://api.discogs.com/database/search?${params.toString()}`)
     console.log(data)

--- a/components/albumDetailmodal.tsx
+++ b/components/albumDetailmodal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getTracks } from "@/lib/tracklist";
+import { getTracks, getArtistReleases } from "@/lib/tracklist";
 import { Artist, DiscogsRelease } from "@/lib/types/DiscogsRelease";
 import { Check, Heart, Plus, Share2, X } from "lucide-react";
 import Image from "next/image";
@@ -8,7 +8,7 @@ import { useState, useEffect } from "react";
 import { DrawerClose, DrawerDescription, DrawerTitle } from "./ui/drawer";
 import { Vinyl } from "@/lib/types/tables";
 
-import useWishlist from "@/hooks/useWistList";
+import { addToCollectionFromSearch } from "@/hooks/useWistList";
 
 type AlbumDetailModalProps = {
     album: DiscogsRelease & Partial<Vinyl>
@@ -19,27 +19,41 @@ export default function AlbumDetailModal({ album, initialInCollection, initialIn
     const [tracklist, setTracklist] = useState<any[]>([]);
     const [inCollection, setInCollection] = useState(initialInCollection || album.owned === true || false);
     const [inWishlist, setInWishlist] = useState(initialInWishlist || album.owned === false || false);
-    const { addToCollectionFromSearch } = useWishlist();
+
+    const isArtist = (album as any).type === 'artist';
+    const [artistReleases, setArtistReleases] = useState<any[]>([]);
 
     useEffect(() => {
-        async function fetchTracks() {
-            const id = album?.master_id || album?.discogs_id
-            if (id) {
+        if (isArtist) {
+            async function fetchReleases() {
                 try {
-                    const data = await getTracks(id.toString());
-                    console.log({ tracklist: data.tracklist });
-                    setTracklist(data.tracklist || []);
+                    const data = await getArtistReleases(String(album.id));
+                    setArtistReleases(data.releases || []);
                 } catch (error) {
-                    console.error("Failed to fetch tracks", error);
+                    console.error("Failed to fetch artist releases", error);
                 }
             }
-        }
-        if (album.tracklist && album.tracklist.length > 0) {
-            setTracklist(album.tracklist);
+            fetchReleases();
         } else {
-            fetchTracks();
+            async function fetchTracks() {
+                const id = album?.master_id || album?.discogs_id
+                if (id) {
+                    try {
+                        const data = await getTracks(id.toString());
+                        console.log({ tracklist: data.tracklist });
+                        setTracklist(data.tracklist || []);
+                    } catch (error) {
+                        console.error("Failed to fetch tracks", error);
+                    }
+                }
+            }
+            if (album.tracklist && album.tracklist.length > 0) {
+                setTracklist(album.tracklist);
+            } else {
+                fetchTracks();
+            }
         }
-    }, [album?.master_id, album?.discogs_id]);
+    }, [isArtist, album?.id, album?.tracklist, album?.master_id, album?.discogs_id]);
 
     const imageUrl = Array.isArray(album.images) ? album.images[0].uri : (album.cover_image ?? album.thumb);
     return (
@@ -112,21 +126,36 @@ export default function AlbumDetailModal({ album, initialInCollection, initialIn
                     </button>
                 </div>
             </div>
-            {/* Tracklist Section */}
+            {/* Tracklist / Releases Section */}
             <div className="flex-1 overflow-y-auto px-8 pb-8">
-                <h3 className="text-xl font-semibold mb-4 text-white/50">Tracklist</h3>
-                <div className="space-y-4">
-                    {tracklist.map((track: any, index: number) => (
-                        <div key={index} className="flex justify-between items-center text-zinc-300">
-                            <div className="flex gap-4 items-center">
-                                <span className="text-zinc-500 w-6 text-sm">{track.position}</span>
-                                <span className="font-medium">{track.title}</span>
+                <h3 className="text-xl font-semibold mb-4 text-white/50">{isArtist ? 'Releases' : 'Tracklist'}</h3>
+                {isArtist ? (
+                    <div className="space-y-4">
+                        {artistReleases.map((release: any, index: number) => (
+                            <div key={index} className="flex gap-4 items-center text-zinc-300">
+                                <Image src={release.thumb || '/placeholder.png'} width={48} height={48} className="rounded object-cover w-12 h-12" alt={release.title} />
+                                <div className="flex-1 min-w-0">
+                                    <p className="font-medium text-white line-clamp-1">{release.title}</p>
+                                    <p className="text-sm text-zinc-500">{release.year}</p>
+                                </div>
                             </div>
-                            <span className="text-sm text-zinc-500">{track.duration}</span>
-                        </div>
-                    ))}
-                    {tracklist.length === 0 && <p className="text-zinc-500 text-sm">No tracks available.</p>}
-                </div>
+                        ))}
+                        {artistReleases.length === 0 && <p className="text-zinc-500 text-sm">No releases available.</p>}
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        {tracklist.map((track: any, index: number) => (
+                            <div key={index} className="flex justify-between items-center text-zinc-300">
+                                <div className="flex gap-4 items-center">
+                                    <span className="text-zinc-500 w-6 text-sm">{track.position}</span>
+                                    <span className="font-medium">{track.title}</span>
+                                </div>
+                                <span className="text-sm text-zinc-500">{track.duration}</span>
+                            </div>
+                        ))}
+                        {tracklist.length === 0 && <p className="text-zinc-500 text-sm">No tracks available.</p>}
+                    </div>
+                )}
             </div>
         </div>
     )

--- a/components/searchResultItem.tsx
+++ b/components/searchResultItem.tsx
@@ -2,8 +2,7 @@ import { DiscogsRelease } from "@/lib/types/DiscogsRelease";
 import { useState } from "react";
 import { Heart, Plus } from "lucide-react";
 import { AlbumDrawer } from "./card";
-import useWishlist from "@/hooks/useWistList";
-
+import { addToCollectionFromSearch } from "@/hooks/useWistList";
 interface SearchResultItemProps {
     album: DiscogsRelease;
     initialInCollection?: boolean;
@@ -13,7 +12,6 @@ interface SearchResultItemProps {
 export function SearchResultItem({ album, initialInCollection = false, initialInWishlist = false }: SearchResultItemProps) {
     const [inCollection, setInCollection] = useState(initialInCollection);
     const [inWishlist, setInWishlist] = useState(initialInWishlist);
-    const { addToCollectionFromSearch } = useWishlist()
 
     return (
         <div className="flex items-center gap-4 p-3 rounded-2xl bg-zinc-900/50 hover:bg-zinc-900 transition-colors">
@@ -22,7 +20,7 @@ export function SearchResultItem({ album, initialInCollection = false, initialIn
                     <img
                         src={album?.cover_image || ''}
                         alt={album.title}
-                        className="w-16 h-16 rounded-lg object-cover shadow-lg flex-shrink-0"
+                        className="w-16 h-16 rounded-lg object-cover shadow-lg shrink-0"
                     />
                     <div className="flex-1 min-w-0 text-left">
                         <p className="font-medium text-sm line-clamp-1">{album.title}</p>
@@ -33,7 +31,7 @@ export function SearchResultItem({ album, initialInCollection = false, initialIn
                     </div>
                 </div>
             </AlbumDrawer>
-            <div className="flex gap-2 flex-shrink-0">
+            <div className="flex gap-2 shrink-0">
                 <button
                     onClick={(e) => {
                         e.stopPropagation();

--- a/hooks/useWistList.ts
+++ b/hooks/useWistList.ts
@@ -69,18 +69,24 @@ export default function useWishlist() {
             toast.success('Album added to collection')
             setWishList(wishlist.filter((album) => album.id !== albumId))
         })
-
-    }
-    const addToCollectionFromSearch = async (albumId: number, owned: boolean) => {
-        await fetch('/api/insert/item', {
-            method: 'POST',
-            body: JSON.stringify({
-                masterId: albumId,
-                owned,
-            })
-        })
     }
 
+    const addToCollectionFromSearchHook = async (albumId: number, owned: boolean) => {
+        await addToCollectionFromSearch(albumId, owned)
+    }
 
-    return { wishlist, isLoading, genres, addToCollectionFormWishList, addToCollectionFromSearch }
+    return { wishlist, isLoading, genres, addToCollectionFormWishList, addToCollectionFromSearch: addToCollectionFromSearchHook }
 }
+
+export const addToCollectionFromSearch = async (albumId: number, owned: boolean) => {
+    await fetch('/api/insert/item', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            masterId: albumId,
+            owned,
+        })
+    })
+}

--- a/lib/tracklist.ts
+++ b/lib/tracklist.ts
@@ -3,3 +3,8 @@ export async function getTracks(masterId: string) {
     const results = await fetch(`/api/discogs/master/${masterId}`)
     return results.json()
 }
+
+export async function getArtistReleases(artistId: string) {
+    const results = await fetch(`/api/discogs/artist/${artistId}`)
+    return results.json()
+}


### PR DESCRIPTION
Included fixes from the latest work: Refactored lbumDetailModal to load artist releases instead of tracklists if the searched result reflects an artist. Re-architected useWishlist to prevent looping API calls when parsing searchResultItem. [Auto-generated PR]